### PR TITLE
NRF51 Port

### DIFF
--- a/ports/atmega32u4/src/nrf51.c
+++ b/ports/atmega32u4/src/nrf51.c
@@ -1,0 +1,2 @@
+// implement rf.h for nrf51 as in mitosis receiver. Data is piped to nrf51 over UART
+// nrf51 should handle encryption and decryption of data with the built in AES accelerator

--- a/ports/atmega32u4/src/uart.c
+++ b/ports/atmega32u4/src/uart.c
@@ -1,0 +1,1 @@
+// implement UART driver for 32u4 to talk to nrf51 on mitosis receivers

--- a/ports/nrf51/README.md
+++ b/ports/nrf51/README.md
@@ -1,0 +1,10 @@
+# NRF51 Support
+
+Support for the common nrf51 modules. Should work for receiving (needs extra hardware such as atmega32u4) and transmitting.
+
+## Features todo
+
+1. Add UART support and integrate with 32u4 for support of [mitosis receivers](https://github.com/reversebias/mitosis-hardware)
+2. Encryption/decryption on nrf51 chip as it is faster than the 32u4. NRF51 has AES encryption hardware, but not decryption, so use [cifra](https://github.com/ctz/cifra) for that.
+3. Compatibility with ESB protocol to work with all nrf24 based boards
+4. *Maybe* write a bootloader for nrf51 so it can be updated over UART for the receiver. People with nrf51 based boards would still have to update the transmitters with a SWD programmer.

--- a/ports/nrf51/todo.txt
+++ b/ports/nrf51/todo.txt
@@ -1,4 +1,0 @@
-Include SDK v12 files for: 
-	UART (mitosis receiver)
-	AES ECB (nrf_ecb.h in the HAL)
-	ESB

--- a/ports/nrf51/todo.txt
+++ b/ports/nrf51/todo.txt
@@ -1,0 +1,4 @@
+Include SDK v12 files for: 
+	UART (mitosis receiver)
+	AES ECB (nrf_ecb.h in the HAL)
+	ESB


### PR DESCRIPTION
Putting this here as I work on integrating the nrf51 chips via the ESB protocol for the following use cases.

- Mitosis receiver with atmega32u4 and nrf51 communicating via uart. Encryption to be done by the nrf51 built in hardware (see discussion below)
    - Should work with any keyplus compatible transmitter.

- Mitosis/chimera/orthrus wireless split keyboards, where each half contains an nrf51 board that transmits to the receiver above.
    - Should work with any keyplus compatible receiver. 

The only challenge I foresee is the crypto hardware of the nrf51/nrf52 series. These chips can only do encryption via AES and are designed to be used with CTR based modes of operation which only rely on encryption operations. They all have BLE compliant AES-CCM hardware that can perform authenticated encryption/decryption, where each packet is a 27 byte payload + 1 byte length field + 4 byte message integrity check. The nrf52840 is an exception here, as it has ARM CryptoCell which should be able to do decryption of AES ciphertext.

I will just implement software based decryption using [cifra](https://github.com/ctz/cifra), the nrf51 chips should be able to do this fast enough for a keyboard.

~Using the built in AES-CCM hardware has the benefit of being able to encrypt/decrypt packets on the fly as they are being transmitted/received and is also the most straightforward implementation in the nrf5 series. However, it also means either a rewrite of the existing security code for the AVR, or having two different security protocols coexist. Not sure how to proceed here. I don't believe CCM is optimal for the small (1 block) stream that keyplus.~